### PR TITLE
Gentle localisation hanges to allow app to initialise and launch

### DIFF
--- a/config/Migrations/20180622201233_Install.php
+++ b/config/Migrations/20180622201233_Install.php
@@ -464,7 +464,7 @@ class Install extends AbstractMigration {
 			])
 			->addColumn('short_name', 'string', [
 				'default' => '',
-				'limit' => 3,
+				'limit' => 16,
 				'null' => false,
 			])
 			->create();

--- a/config/Seeds/CountriesSeed.php
+++ b/config/Seeds/CountriesSeed.php
@@ -13,11 +13,12 @@ class CountriesSeed extends AbstractSeed {
 	public function data() {
 		return [
 			[
-				'name' => __d('seeds', 'Canada'),
-			],
+				'name' => __d('seeds', 'United Kingdom'),
+				//'name' => __d('seeds', 'Canada'),
+			]/*,
 			[
 				'name' => __d('seeds', 'United States'),
-			],
+			],*/
 		];
 	}
 


### PR DESCRIPTION
Updated the limit to short days which was causing a database error at start up because somewhere something was trying to shove too many characters in days. I believe its to do with the translations (in French it showed the short day for Sunday to be "Soleil" which is more than 3 characters.

There is also the commenting out of Canada and US in seeding operations to see if that fixed the issue above. It didn't but I left it like that for now.